### PR TITLE
Update aws provider requirements

### DIFF
--- a/aws/versions.tf
+++ b/aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = ">= 4.0"
     }
     random = {
       source = "hashicorp/random"


### PR DESCRIPTION
Having `~> 4.0` will fail, since 5.0 is out and there are multiple modules requiring >= 5.0.

`terraform init` will fail due to this and one cannot start the Instruqt test thingy.